### PR TITLE
Fix typo in HistoryRequestVolume.SUM's string value

### DIFF
--- a/src/main/java/com/barchart/ondemand/api/HistoryRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/HistoryRequest.java
@@ -81,7 +81,7 @@ public class HistoryRequest implements OnDemandRequest {
 			case TOTAL:
 				return "total";
 			case SUM:
-				return "sun";
+				return "sum";
 			case SUM_CONTRACT:
 				return "sumcontract";
 			case SUM_TOTAL:


### PR DESCRIPTION
According to the [documentation](http://www.barchartondemand.com/api/getHistory) the correct value should be 'sum'.
