### PR TITLE
Use the all() helper function to beat ambiguity with 'results'

### DIFF
--- a/src/main/java/com/barchart/ondemand/api/responses/BalanceSheets.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/BalanceSheets.java
@@ -24,7 +24,7 @@ public class BalanceSheets extends ResponseBase {
 			return null;
 		}
 
-		for (BalanceSheet fh : results) {
+		for (BalanceSheet fh : all()) {
 			if (fh.getSymbol() != null && fh.getSymbol().equalsIgnoreCase(symbol)) {
 				return fh;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/Charts.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/Charts.java
@@ -24,7 +24,7 @@ public class Charts extends ResponseBase {
 			return null;
 		}
 
-		for (Chart fh : results) {
+		for (Chart fh : all()) {
 			if (fh.getSymbol() != null && fh.getSymbol().equalsIgnoreCase(symbol)) {
 				return fh;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/Competitors.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/Competitors.java
@@ -24,7 +24,7 @@ public class Competitors extends ResponseBase {
 			return null;
 		}
 
-		for (Competitor fh : results) {
+		for (Competitor fh : all()) {
 			if (fh.getSymbol() != null && fh.getSymbol().equalsIgnoreCase(symbol)) {
 				return fh;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/CorporateActions.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/CorporateActions.java
@@ -34,7 +34,7 @@ public class CorporateActions extends ResponseBase {
 
 		final List<CorporateAction> results = new ArrayList<CorporateAction>();
 
-		for (CorporateAction a : results) {
+		for (CorporateAction a : all()) {
 			if (a.getEventType().equalsIgnoreCase(type.name())) {
 				results.add(a);
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/FinancialHighlights.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/FinancialHighlights.java
@@ -24,7 +24,7 @@ public class FinancialHighlights extends ResponseBase {
 			return null;
 		}
 
-		for (FinancialHighlight fh : results) {
+		for (FinancialHighlight fh : all()) {
 			if (fh.getSymbol() != null && fh.getSymbol().equalsIgnoreCase(symbol)) {
 				return fh;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/FinancialRatios.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/FinancialRatios.java
@@ -24,7 +24,7 @@ public class FinancialRatios extends ResponseBase {
 			return null;
 		}
 
-		for (FinancialRatio fh : results) {
+		for (FinancialRatio fh : all()) {
 			if (fh.getSymbol() != null && fh.getSymbol().equalsIgnoreCase(symbol)) {
 				return fh;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/FuturesSpecifications.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/FuturesSpecifications.java
@@ -26,7 +26,7 @@ public class FuturesSpecifications extends ResponseBase {
 			return null;
 		}
 
-		for (FuturesSpecification fh : results) {
+		for (FuturesSpecification fh : all()) {
 			if (fh.getSymbol() != null && fh.getSymbol().equalsIgnoreCase(symbol)) {
 				return fh;
 			}
@@ -46,7 +46,7 @@ public class FuturesSpecifications extends ResponseBase {
 			return res;
 		}
 
-		for (FuturesSpecification fh : results) {
+		for (FuturesSpecification fh : all()) {
 			if (fh.getExchange() != null && fh.getExchange().equalsIgnoreCase(exchange)) {
 				res.add(fh);
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/IncomeStatements.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/IncomeStatements.java
@@ -21,7 +21,7 @@ public class IncomeStatements extends ResponseBase {
 			return null;
 		}
 
-		for (IncomeStatement p : results) {
+		for (IncomeStatement p : all()) {
 			if (p.getSymbol() != null && p.getSymbol().equalsIgnoreCase(symbol)) {
 				return p;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/IndexMembers.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/IndexMembers.java
@@ -34,7 +34,7 @@ public class IndexMembers extends ResponseBase {
 
 		final List<IndexMember> results = new ArrayList<IndexMember>();
 
-		for (IndexMember m : this.results) {
+		for (IndexMember m : all()) {
 			if (m.getIndex().equalsIgnoreCase(index)) {
 				results.add(m);
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/InstrumentDefinitions.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/InstrumentDefinitions.java
@@ -25,7 +25,7 @@ public class InstrumentDefinitions extends ResponseBase {
 			return null;
 		}
 
-		for (InstrumentDefinition fh : results) {
+		for (InstrumentDefinition fh : all()) {
 			if (fh.getSymbol() != null && fh.getSymbol().equalsIgnoreCase(symbol)) {
 				return fh;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/Momentums.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/Momentums.java
@@ -22,7 +22,7 @@ public class Momentums extends ResponseBase {
 			return null;
 		}
 
-		for (Momentum p : results) {
+		for (Momentum p : all()) {
 			if (p.getExchange() != null && p.getExchange().equalsIgnoreCase(exchange)) {
 				return p;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/Profiles.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/Profiles.java
@@ -22,7 +22,7 @@ public class Profiles extends ResponseBase {
 			return null;
 		}
 
-		for (Profile p : results) {
+		for (Profile p : all()) {
 			if (p.getSymbol() != null && p.getSymbol().equalsIgnoreCase(symbol)) {
 				return p;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/Quotes.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/Quotes.java
@@ -22,7 +22,7 @@ public class Quotes extends ResponseBase {
 			return null;
 		}
 
-		for (Quote p : results) {
+		for (Quote p : all()) {
 			if (p.getSymbol() != null && p.getSymbol().equalsIgnoreCase(symbol)) {
 				return p;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/Ratings.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/Ratings.java
@@ -19,7 +19,7 @@ public class Ratings extends ResponseBase {
 			return null;
 		}
 
-		for (Rating p : results) {
+		for (Rating p : all()) {
 			if (p.getSymbol() != null && p.getSymbol().equalsIgnoreCase(symbol)) {
 				return p;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/Signals.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/Signals.java
@@ -19,7 +19,7 @@ public class Signals extends ResponseBase {
 			return null;
 		}
 
-		for (Signal p : results) {
+		for (Signal p : all()) {
 			if (p.getSymbol() != null && p.getSymbol().equalsIgnoreCase(symbol)) {
 				return p;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/SpecialOptionsClassifications.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/SpecialOptionsClassifications.java
@@ -26,7 +26,7 @@ public class SpecialOptionsClassifications extends ResponseBase {
 			return null;
 		}
 
-		for (SpecialOptionsClassification soc : results) {
+		for (SpecialOptionsClassification soc : all()) {
 			if (soc.getRoot().equals(root)) {
 				return soc;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/Technicals.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/Technicals.java
@@ -22,7 +22,7 @@ public class Technicals extends ResponseBase {
 			return null;
 		}
 
-		for (Technical p : results) {
+		for (Technical p : all()) {
 			if (p.getSymbol() != null && p.getSymbol().equalsIgnoreCase(symbol)) {
 				return p;
 			}

--- a/src/main/java/com/barchart/ondemand/api/responses/USDAGrains.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/USDAGrains.java
@@ -22,7 +22,7 @@ public class USDAGrains extends ResponseBase {
 			return null;
 		}
 
-		for (USDAGrain p : results) {
+		for (USDAGrain p : all()) {
 			if (p.getCommodityType() != null && p.getCommodityType().equalsIgnoreCase(symbol)) {
 				return p;
 			}


### PR DESCRIPTION
In `IndexMembers`, `this.results` is correctly used, but in `CorporateActions`, `results` hides the field with the same name.

These changes would also allow to easily add null-safety checks in `all()`.
