### PR TITLE
Add compile time safety to the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ builder.mode(QuoteRequestMode.REAL_TIME);
 builder.fields(new QuoteRequestField[] { QuoteRequestField._52_WEEK_HIGH_DATE });
 
 /* fetch results */
-final Quotes quotes = (Quotes) onDemand.fetch(builder.build());
+final Quotes quotes = onDemand.fetch(builder.build());
 
 for (Quote q : quotes.all()) {
 	System.out.println("Quote for : " + q.getSymbol() + " = " + q);

--- a/src/main/java/com/barchart/ondemand/BarchartOnDemandClient.java
+++ b/src/main/java/com/barchart/ondemand/BarchartOnDemandClient.java
@@ -86,8 +86,6 @@ public class BarchartOnDemandClient {
 
 	private final OkHttpClient http = new OkHttpClient();
 
-	public static final Map<Class<?>, Class<?>> responseMap = new HashMap<Class<?>, Class<?>>();
-
 	//
 
 	private BarchartOnDemandClient(final Builder b) {
@@ -95,35 +93,11 @@ public class BarchartOnDemandClient {
 		this.baseUrl = b.baseUrl;
 		this.cacheTime = b.cacheTime;
 		this.debug = b.debug;
-
-		responseMap.put(QuoteRequest.class, Quotes.class);
-		responseMap.put(TechnicalsRequest.class, Technicals.class);
-		responseMap.put(SignalsRequest.class, Signals.class);
-		responseMap.put(BalanceSheetsRequest.class, BalanceSheets.class);
-		responseMap.put(CompetitorsRequest.class, Competitors.class);
-		responseMap.put(CorporateActionsRequest.class, CorporateActions.class);
-		responseMap.put(FinancialHighlightRequest.class, FinancialHighlights.class);
-		responseMap.put(FinancialRatioRequest.class, FinancialRatios.class);
-		responseMap.put(IncomeStatementRequest.class, IncomeStatements.class);
-		responseMap.put(IndexMembersRequest.class, IndexMembers.class);
-		responseMap.put(ProfileRequest.class, Profiles.class);
-		responseMap.put(RatingsRequest.class, Ratings.class);
-		responseMap.put(FuturesOptionsRequest.class, FuturesOptions.class);
-		responseMap.put(SDFuturesOptionsRequest.class, SDFuturesOptions.class);
-		responseMap.put(InstrumentDefinitionRequest.class, InstrumentDefinitions.class);
-		responseMap.put(FuturesSpecificationsRequest.class, FuturesSpecifications.class);
-		responseMap.put(WeatherRequest.class, Weather.class);
-		responseMap.put(LeadersRequest.class, Leaders.class);
-		responseMap.put(MomentumRequest.class, Momentums.class);
-		responseMap.put(ChartRequest.class, Charts.class);
-		responseMap.put(USDAGrainsRequest.class, USDAGrains.class);
-		responseMap.put(HistoryRequest.class, History.class);
-		responseMap.put(SpecialOptionsClassificationRequest.class, SpecialOptionsClassifications.class);
 	}
 
 	//
 
-	public <T extends OnDemandResponse> OnDemandResponse fetch(final OnDemandRequest request) throws Exception {
+	public <T extends ResponseBase> T fetch(final OnDemandRequest<T> request) throws Exception {
 
 		if (request == null) {
 			throw new RuntimeException("request cannot be null.");
@@ -144,7 +118,7 @@ public class BarchartOnDemandClient {
 			System.out.println("query URL = " + sb.toString());
 			System.out.println("response = " + response);
 		}
-		final ResponseBase base = (ResponseBase) JsonUtil.fromJson(responseMap.get(request.getClass()), response);
+		final T base = JsonUtil.fromJson(request.responseType(), response);
 
 		base.configure(request, this);
 
@@ -171,7 +145,7 @@ public class BarchartOnDemandClient {
 
 	}
 
-	private String fetchApiString(final OnDemandRequest request, final OkHttpClient client) throws IOException {
+	private String fetchApiString(final OnDemandRequest<?> request, final OkHttpClient client) throws IOException {
 
 		final StringBuilder sb = new StringBuilder();
 

--- a/src/main/java/com/barchart/ondemand/api/BalanceSheetsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/BalanceSheetsRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class BalanceSheetsRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.BalanceSheets;
+
+public class BalanceSheetsRequest implements OnDemandRequest<BalanceSheets> {
 
 	private final String symbols;
 	private final String fields;
@@ -51,6 +53,11 @@ public class BalanceSheetsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<BalanceSheets> responseType() {
+		return BalanceSheets.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -72,7 +79,7 @@ public class BalanceSheetsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public BalanceSheetsRequest build() {
 			return new BalanceSheetsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/ChartRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/ChartRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class ChartRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Charts;
+
+public class ChartRequest implements OnDemandRequest<Charts> {
 
 	public enum ChartRequestType {
 		BAR, LINE, CANDLE, AREA;
@@ -121,6 +123,11 @@ public class ChartRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Charts> responseType() {
+		return Charts.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -154,7 +161,7 @@ public class ChartRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public ChartRequest build() {
 			return new ChartRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/CompetitorsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/CompetitorsRequest.java
@@ -3,7 +3,9 @@ package com.barchart.ondemand.api;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CompetitorsRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Competitors;
+
+public class CompetitorsRequest implements OnDemandRequest<Competitors> {
 
 	public enum CompetitorsRequestField {
 		_52_WEEK_HIGH, _52_WEEK_HIGH_DATE, _52_WEEK_LOW, _52_WEEK_LOW_DATE;
@@ -84,6 +86,11 @@ public class CompetitorsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Competitors> responseType() {
+		return Competitors.class;
+	}
+
 	public static class Builder {
 
 		private String symbol;
@@ -105,7 +112,7 @@ public class CompetitorsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public CompetitorsRequest build() {
 			return new CompetitorsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/CorporateActionsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/CorporateActionsRequest.java
@@ -5,9 +5,10 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
+import com.barchart.ondemand.api.responses.CorporateActions;
 import com.barchart.ondemand.api.responses.CorporateActions.EventType;
 
-public class CorporateActionsRequest implements OnDemandRequest {
+public class CorporateActionsRequest implements OnDemandRequest<CorporateActions> {
 
 	private final String symbols;
 	private final String fields;
@@ -62,6 +63,11 @@ public class CorporateActionsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<CorporateActions> responseType() {
+		return CorporateActions.class;
+	}
+
 	/* builder magic * */
 
 	public static class Builder {
@@ -85,7 +91,7 @@ public class CorporateActionsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public CorporateActionsRequest build() {
 			return new CorporateActionsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/FinancialHighlightRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/FinancialHighlightRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class FinancialHighlightRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.FinancialHighlights;
+
+public class FinancialHighlightRequest implements OnDemandRequest<FinancialHighlights> {
 
 	public enum FinancialHighlightRequestField {
 		LAST_QTR_EPS, ANNUAL_EPS, TTM_EPS;
@@ -78,6 +80,11 @@ public class FinancialHighlightRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<FinancialHighlights> responseType() {
+		return FinancialHighlights.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -93,7 +100,7 @@ public class FinancialHighlightRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public FinancialHighlightRequest build() {
 			return new FinancialHighlightRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/FinancialRatioRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/FinancialRatioRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class FinancialRatioRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.FinancialRatios;
+
+public class FinancialRatioRequest implements OnDemandRequest<FinancialRatios> {
 
 	public enum FinancialRatioRequestField {
 		DEBT_EQUITY, INTEREST_COVERAGE, BOOK_VALUE, DIVIDEND_PAYOUT;
@@ -76,6 +78,11 @@ public class FinancialRatioRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<FinancialRatios> responseType() {
+		return FinancialRatios.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -91,7 +98,7 @@ public class FinancialRatioRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public FinancialRatioRequest build() {
 			return new FinancialRatioRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/FuturesExiprationsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/FuturesExiprationsRequest.java
@@ -64,6 +64,11 @@ public class FuturesExiprationsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class responseType() {
+		throw new UnsupportedOperationException("Not supported yet.");
+	}
+
 	public static class Builder {
 		private String[] symbols;
 		private String[] exchanges;
@@ -78,7 +83,7 @@ public class FuturesExiprationsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public FuturesExiprationsRequest build() {
 			return new FuturesExiprationsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/FuturesOptionsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/FuturesOptionsRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class FuturesOptionsRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.FuturesOptions;
+
+public class FuturesOptionsRequest implements OnDemandRequest<FuturesOptions> {
 
 	public enum FuturesOptionsRequestType {
 		CALLS, PUTS, ALL;
@@ -80,6 +82,11 @@ public class FuturesOptionsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<FuturesOptions> responseType() {
+		return FuturesOptions.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols = new String[] {};
@@ -102,7 +109,7 @@ public class FuturesOptionsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public FuturesOptionsRequest build() {
 			return new FuturesOptionsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/FuturesSpecificationsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/FuturesSpecificationsRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class FuturesSpecificationsRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.FuturesSpecifications;
+
+public class FuturesSpecificationsRequest implements OnDemandRequest<FuturesSpecifications> {
 
 	private final String symbols;
 	private final String fields;
@@ -53,6 +55,11 @@ public class FuturesSpecificationsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<FuturesSpecifications> responseType() {
+		return FuturesSpecifications.class;
+	}
+
 	public static class Builder {
 		private String[] symbols;
 		private String[] exchanges;
@@ -73,7 +80,7 @@ public class FuturesSpecificationsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public FuturesSpecificationsRequest build() {
 			return new FuturesSpecificationsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/HistoryRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/HistoryRequest.java
@@ -7,7 +7,9 @@ import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-public class HistoryRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.History;
+
+public class HistoryRequest implements OnDemandRequest<History> {
 
 	public static final DateTimeFormatter dateFormat = DateTimeFormat.forPattern("yyyyMMddhhmmss");
 
@@ -159,6 +161,11 @@ public class HistoryRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<History> responseType() {
+		return History.class;
+	}
+
 	public static class Builder {
 
 		private String symbol;
@@ -228,7 +235,7 @@ public class HistoryRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public HistoryRequest build() {
 
 			if (symbol == null) {
 				throw new IllegalArgumentException("you must set the symbol field");

--- a/src/main/java/com/barchart/ondemand/api/IncomeStatementRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/IncomeStatementRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class IncomeStatementRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.IncomeStatements;
+
+public class IncomeStatementRequest implements OnDemandRequest<IncomeStatements> {
 
 	private final String symbols;
 	private final String fields;
@@ -52,6 +54,11 @@ public class IncomeStatementRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<IncomeStatements> responseType() {
+		return IncomeStatements.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -73,7 +80,7 @@ public class IncomeStatementRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public IncomeStatementRequest build() {
 			return new IncomeStatementRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/IndexMembersRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/IndexMembersRequest.java
@@ -3,7 +3,9 @@ package com.barchart.ondemand.api;
 import java.util.HashMap;
 import java.util.Map;
 
-public class IndexMembersRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.IndexMembers;
+
+public class IndexMembersRequest implements OnDemandRequest<IndexMembers> {
 
 	private final String symbol;
 	private final String fields;
@@ -42,6 +44,11 @@ public class IndexMembersRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<IndexMembers> responseType() {
+		return IndexMembers.class;
+	}
+
 	public static class Builder {
 		private String symbol;
 
@@ -50,7 +57,7 @@ public class IndexMembersRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public IndexMembersRequest build() {
 			return new IndexMembersRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/InstrumentDefinitionRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/InstrumentDefinitionRequest.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
+import com.barchart.ondemand.api.responses.InstrumentDefinitions;
+
 /**
  * 
  * @author m-ehrenberg
@@ -13,7 +15,7 @@ import org.apache.commons.lang.StringUtils;
  * 
  */
 
-public class InstrumentDefinitionRequest implements OnDemandRequest {
+public class InstrumentDefinitionRequest implements OnDemandRequest<InstrumentDefinitions> {
 
 	private final String symbols;
 	private final String fields;
@@ -67,6 +69,11 @@ public class InstrumentDefinitionRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<InstrumentDefinitions> responseType() {
+		return InstrumentDefinitions.class;
+	}
+
 	public static class Builder {
 		private String[] symbols;
 		private String[] exchanges;
@@ -99,7 +106,7 @@ public class InstrumentDefinitionRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public InstrumentDefinitionRequest build() {
 			return new InstrumentDefinitionRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/LeadersRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/LeadersRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class LeadersRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Leaders;
+
+public class LeadersRequest implements OnDemandRequest<Leaders> {
 
 	public enum LeadersAssetType {
 		STOCK, ETF, FUTURE, FUND, FOREX;
@@ -169,6 +171,11 @@ public class LeadersRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Leaders> responseType() {
+		return Leaders.class;
+	}
+
 	public static class Builder {
 
 		private String[] exchanges;
@@ -191,7 +198,7 @@ public class LeadersRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public LeadersRequest build() {
 
 			if (type == null) {
 				throw new IllegalArgumentException("you must set the type field, LeadersRequestType");

--- a/src/main/java/com/barchart/ondemand/api/MomentumRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/MomentumRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class MomentumRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Momentums;
+
+public class MomentumRequest implements OnDemandRequest<Momentums> {
 
 	private final String exchanges;
 	private final String fields;
@@ -44,6 +46,11 @@ public class MomentumRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Momentums> responseType() {
+		return Momentums.class;
+	}
+
 	public static class Builder {
 
 		private String[] exchanges;
@@ -53,7 +60,7 @@ public class MomentumRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public MomentumRequest build() {
 			return new MomentumRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/OnDemandRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/OnDemandRequest.java
@@ -2,7 +2,9 @@ package com.barchart.ondemand.api;
 
 import java.util.Map;
 
-public interface OnDemandRequest {
+import com.barchart.ondemand.api.responses.ResponseBase;
+
+public interface OnDemandRequest<R extends ResponseBase> {
 
 	public enum GenericRequestField {
 		QUARTER, ANNUAL;
@@ -27,4 +29,5 @@ public interface OnDemandRequest {
 
 	Map<String, Object> parameters();
 
+	Class<R> responseType();
 }

--- a/src/main/java/com/barchart/ondemand/api/ProfileRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/ProfileRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class ProfileRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Profiles;
+
+public class ProfileRequest implements OnDemandRequest<Profiles> {
 
 	public enum ProfileRequestField {
 		QTR_ONE_EARNINGS, QTR_TWO_EARNINGS, QTR_THREE_EARNINGS, QTR_FOUR_EARNINGS;
@@ -80,6 +82,11 @@ public class ProfileRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Profiles> responseType() {
+		return Profiles.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -95,7 +102,7 @@ public class ProfileRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public ProfileRequest build() {
 			return new ProfileRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/QuoteRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/QuoteRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class QuoteRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Quotes;
+
+public class QuoteRequest implements OnDemandRequest<Quotes> {
 
 	public enum QuoteRequestMode {
 		REAL_TIME, DELAYED, END_OF_DAY;
@@ -105,6 +107,11 @@ public class QuoteRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Quotes> responseType() {
+		return Quotes.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -126,7 +133,7 @@ public class QuoteRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public QuoteRequest build() {
 			return new QuoteRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/RatingsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/RatingsRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class RatingsRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Ratings;
+
+public class RatingsRequest implements OnDemandRequest<Ratings> {
 
 	public enum RatingsRequestField {
 		STRONG_BUY, HOLD, STRONG_SELL;
@@ -78,6 +80,11 @@ public class RatingsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Ratings> responseType() {
+		return Ratings.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -93,7 +100,7 @@ public class RatingsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public RatingsRequest build() {
 			return new RatingsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/SDFuturesOptionsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/SDFuturesOptionsRequest.java
@@ -3,7 +3,9 @@ package com.barchart.ondemand.api;
 import java.util.HashMap;
 import java.util.Map;
 
-public class SDFuturesOptionsRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.SDFuturesOptions;
+
+public class SDFuturesOptionsRequest implements OnDemandRequest<SDFuturesOptions> {
 
 	public enum FuturesOptionsRequestType {
 		CALLS, PUTS, ALL;
@@ -71,6 +73,11 @@ public class SDFuturesOptionsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<SDFuturesOptions> responseType() {
+		return SDFuturesOptions.class;
+	}
+
 	public static class Builder {
 
 		private FuturesOptionsRequestType type;
@@ -87,7 +94,7 @@ public class SDFuturesOptionsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public SDFuturesOptionsRequest build() {
 			return new SDFuturesOptionsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/SignalsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/SignalsRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class SignalsRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Signals;
+
+public class SignalsRequest implements OnDemandRequest<Signals> {
 
 	private final String symbols;
 	private final String fields;
@@ -44,6 +46,11 @@ public class SignalsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Signals> responseType() {
+		return Signals.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -59,7 +66,7 @@ public class SignalsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public SignalsRequest build() {
 			return new SignalsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/SpecialOptionsClassificationRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/SpecialOptionsClassificationRequest.java
@@ -3,7 +3,9 @@ package com.barchart.ondemand.api;
 import java.util.HashMap;
 import java.util.Map;
 
-public class SpecialOptionsClassificationRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.SpecialOptionsClassifications;
+
+public class SpecialOptionsClassificationRequest implements OnDemandRequest<SpecialOptionsClassifications> {
 
 	private final String symbols;
 	private final String fields;
@@ -40,6 +42,11 @@ public class SpecialOptionsClassificationRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<SpecialOptionsClassifications> responseType() {
+		return SpecialOptionsClassifications.class;
+	}
+
 	public static class Builder {
 
 		private String root;
@@ -49,7 +56,7 @@ public class SpecialOptionsClassificationRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public SpecialOptionsClassificationRequest build() {
 			return new SpecialOptionsClassificationRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/TechnicalsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/TechnicalsRequest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
-public class TechnicalsRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Technicals;
+
+public class TechnicalsRequest implements OnDemandRequest<Technicals> {
 
 	private final String symbols;
 	private final String fields;
@@ -44,6 +46,11 @@ public class TechnicalsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Technicals> responseType() {
+		return Technicals.class;
+	}
+
 	public static class Builder {
 
 		private String[] symbols;
@@ -59,7 +66,7 @@ public class TechnicalsRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public TechnicalsRequest build() {
 			return new TechnicalsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/USDAGrainsRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/USDAGrainsRequest.java
@@ -3,7 +3,9 @@ package com.barchart.ondemand.api;
 import java.util.HashMap;
 import java.util.Map;
 
-public class USDAGrainsRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.USDAGrains;
+
+public class USDAGrainsRequest implements OnDemandRequest<USDAGrains> {
 
 	private final String fields;
 
@@ -37,9 +39,14 @@ public class USDAGrainsRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<USDAGrains> responseType() {
+		return USDAGrains.class;
+	}
+
 	public static class Builder {
 
-		public OnDemandRequest build() {
+		public USDAGrainsRequest build() {
 			return new USDAGrainsRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/WeatherRequest.java
+++ b/src/main/java/com/barchart/ondemand/api/WeatherRequest.java
@@ -3,7 +3,9 @@ package com.barchart.ondemand.api;
 import java.util.HashMap;
 import java.util.Map;
 
-public class WeatherRequest implements OnDemandRequest {
+import com.barchart.ondemand.api.responses.Weather;
+
+public class WeatherRequest implements OnDemandRequest<Weather> {
 
 	public enum WeatherRequestType {
 		CURRENT_CONTIDIONS, FORECAST, MAP;
@@ -100,6 +102,11 @@ public class WeatherRequest implements OnDemandRequest {
 		return params;
 	}
 
+	@Override
+	public Class<Weather> responseType() {
+		return Weather.class;
+	}
+
 	public static class Builder {
 
 		private String zipCode;
@@ -133,7 +140,7 @@ public class WeatherRequest implements OnDemandRequest {
 			return this;
 		}
 
-		public OnDemandRequest build() {
+		public WeatherRequest build() {
 			return new WeatherRequest(this);
 		}
 	}

--- a/src/main/java/com/barchart/ondemand/api/responses/OnDemandResponse.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/OnDemandResponse.java
@@ -15,7 +15,7 @@ public interface OnDemandResponse {
 	 * 
 	 * @return
 	 */
-	public OnDemandRequest getRequest();
+	public OnDemandRequest<?> getRequest();
 
 	/**
 	 * Reruns the original query. Makes a new call and updates all data in the

--- a/src/main/java/com/barchart/ondemand/api/responses/ResponseBase.java
+++ b/src/main/java/com/barchart/ondemand/api/responses/ResponseBase.java
@@ -16,19 +16,19 @@ public class ResponseBase implements OnDemandResponse {
 	@JsonProperty("status")
 	protected final Map<String, Object> status = new HashMap<String, Object>();
 
-	protected OnDemandRequest request;
+	protected OnDemandRequest<?> request;
 	protected BarchartOnDemandClient client;
 
 	public ResponseBase() {
 
 	}
 
-	public void configure(final OnDemandRequest r, final BarchartOnDemandClient c) {
+	public void configure(final OnDemandRequest<?> r, final BarchartOnDemandClient c) {
 		this.request = r;
 		this.client = c;
 	}
 
-	public OnDemandRequest getRequest() {
+	public OnDemandRequest<?> getRequest() {
 		return this.request;
 	}
 

--- a/src/test/java/ClientSandbox.java
+++ b/src/test/java/ClientSandbox.java
@@ -25,7 +25,7 @@ public class ClientSandbox {
 		builder.symbols(new String[] { "AAPL", "AMZN" });
 		builder.fields(new TechnicalsRequestField[] { TechnicalsRequestField.HIST_VOL_20_DAY });
 
-		final Technicals results = (Technicals) onDemand.fetch(builder.build());
+		final Technicals results = onDemand.fetch(builder.build());
 
 		for (Technical q : results.all()) {
 			System.out.println("Tech : " + q.getSymbol() + ", 20 day historic vol = "
@@ -39,7 +39,7 @@ public class ClientSandbox {
 		qBuilder.fields(QuoteRequestField.values());
 		qBuilder.symbols(new String[] { "APPL", "NEM", "TBY0", "GH*1" });
 
-		final Quotes qResults = (Quotes) onDemand.fetch(qBuilder.build());
+		final Quotes qResults = onDemand.fetch(qBuilder.build());
 
 		for (Quote q : qResults.all()) {
 			System.out.println("Quote : " + q.getSymbol() + " last = " + q.getLastPrice());

--- a/src/test/java/ClientTest.java
+++ b/src/test/java/ClientTest.java
@@ -29,7 +29,7 @@ public class ClientTest {
 		builder.fields(new QuoteRequestField[] { QuoteRequestField._52_WEEK_HIGH_DATE });
 
 		/* fetch results */
-		final Quotes quotes = (Quotes) onDemand.fetch(builder.build());
+		final Quotes quotes = onDemand.fetch(builder.build());
 
 		for (Quote q : quotes.all()) {
 			System.out.println("Quote for : " + q.getSymbol() + " = " + q);

--- a/src/test/java/MainTest.java
+++ b/src/test/java/MainTest.java
@@ -169,7 +169,7 @@ public class MainTest {
 		final SpecialOptionsClassificationRequest.Builder builder = new SpecialOptionsClassificationRequest.Builder()
 				.root("ZC");
 
-		final OnDemandRequest p = builder.build();
+		final SpecialOptionsClassificationRequest p = builder.build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -194,7 +194,7 @@ public class MainTest {
 		final HistoryRequest.Builder builder = new HistoryRequest.Builder().symbol("AAPL")
 				.start(new DateTime(2012, 2, 3, 11, 11)).end(new DateTime(2012, 3, 3, 11, 11));
 
-		final OnDemandRequest p = builder.build();
+		final HistoryRequest p = builder.build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -211,7 +211,7 @@ public class MainTest {
 
 		builder.eventTypes(new ProfileRequestField[] { ProfileRequestField.QTR_FOUR_EARNINGS });
 
-		final OnDemandRequest p = builder.build();
+		final ProfileRequest p = builder.build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -224,7 +224,7 @@ public class MainTest {
 
 	private void testFinancialHighlights() throws IOException {
 
-		final OnDemandRequest p = new FinancialHighlightRequest.Builder().symbols(new String[] { "AAPL", "GOOG" })
+		final FinancialHighlightRequest p = new FinancialHighlightRequest.Builder().symbols(new String[] { "AAPL", "GOOG" })
 				.build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
@@ -238,7 +238,7 @@ public class MainTest {
 
 	private void testFinancialRatios() throws IOException {
 
-		final OnDemandRequest p = new FinancialRatioRequest.Builder().symbols(new String[] { "AAPL", "GOOG" }).build();
+		final FinancialRatioRequest p = new FinancialRatioRequest.Builder().symbols(new String[] { "AAPL", "GOOG" }).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -257,7 +257,7 @@ public class MainTest {
 		pBuilder.eventTypes(GenericRequestField.ANNUAL);
 		pBuilder.count(2);
 
-		final OnDemandRequest p = pBuilder.build();
+		final IncomeStatementRequest p = pBuilder.build();
 
 		String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -270,7 +270,7 @@ public class MainTest {
 
 	private void testBalanceSheets() throws IOException {
 
-		final OnDemandRequest p = new BalanceSheetsRequest.Builder().symbols(new String[] { "AAPL", "GOOG" }).build();
+		final BalanceSheetsRequest p = new BalanceSheetsRequest.Builder().symbols(new String[] { "AAPL", "GOOG" }).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -283,7 +283,7 @@ public class MainTest {
 
 	private void testCompetitors() throws IOException {
 
-		final OnDemandRequest p = new CompetitorsRequest.Builder().symbol("GOOG")
+		final CompetitorsRequest p = new CompetitorsRequest.Builder().symbol("GOOG")
 				.eventTypes(new CompetitorsRequestField[] { CompetitorsRequestField._52_WEEK_HIGH }).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
@@ -297,7 +297,7 @@ public class MainTest {
 
 	private void testRatings() throws IOException {
 
-		final OnDemandRequest p = new RatingsRequest.Builder()
+		final RatingsRequest p = new RatingsRequest.Builder()
 				.symbols(new String[] { "GOOG, AAPL" })
 				.eventTypes(
 						new RatingsRequestField[] { RatingsRequestField.STRONG_BUY, RatingsRequestField.STRONG_SELL })
@@ -315,7 +315,7 @@ public class MainTest {
 
 	private void testIndexMembers() throws IOException {
 
-		final OnDemandRequest p = new IndexMembersRequest.Builder().symbol("$ONE").build();
+		final IndexMembersRequest p = new IndexMembersRequest.Builder().symbol("$ONE").build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -328,7 +328,7 @@ public class MainTest {
 
 	private void testCorpActions() throws IOException {
 
-		final OnDemandRequest p = new CorporateActionsRequest.Builder().symbols(new String[] { "AAPL", "NEM" })
+		final CorporateActionsRequest p = new CorporateActionsRequest.Builder().symbols(new String[] { "AAPL", "NEM" })
 				.maxRecords(10).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
@@ -342,7 +342,7 @@ public class MainTest {
 
 	private void testQuote() throws IOException {
 
-		final OnDemandRequest p = new QuoteRequest.Builder().symbols(new String[] { "AAPL", "NEM" })
+		final QuoteRequest p = new QuoteRequest.Builder().symbols(new String[] { "AAPL", "NEM" })
 				.mode(QuoteRequestMode.REAL_TIME).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
@@ -354,7 +354,7 @@ public class MainTest {
 
 	private void testFuturesOptions() throws IOException {
 
-		final OnDemandRequest p = new FuturesOptionsRequest.Builder().contract("ESU14").build();
+		final FuturesOptionsRequest p = new FuturesOptionsRequest.Builder().contract("ESU14").build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -367,7 +367,7 @@ public class MainTest {
 
 	private void testSDFuturesOptions() throws IOException {
 
-		final OnDemandRequest p = new SDFuturesOptionsRequest.Builder().root("ZC").build();
+		final SDFuturesOptionsRequest p = new SDFuturesOptionsRequest.Builder().root("ZC").build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -386,7 +386,7 @@ public class MainTest {
 
 	private void testTechnicals() throws IOException {
 
-		final OnDemandRequest p = new TechnicalsRequest.Builder().symbols(new String[] { "AAPL" })
+		final TechnicalsRequest p = new TechnicalsRequest.Builder().symbols(new String[] { "AAPL" })
 				.fields(TechnicalsRequestField.all()).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
@@ -400,7 +400,7 @@ public class MainTest {
 
 	private void testSignals() throws IOException {
 
-		final OnDemandRequest p = new SignalsRequest.Builder().symbols(new String[] { "AAPL" })
+		final SignalsRequest p = new SignalsRequest.Builder().symbols(new String[] { "AAPL" })
 				.fields(SignalsRequestField.all()).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
@@ -414,7 +414,7 @@ public class MainTest {
 
 	private void testMomentums() throws IOException {
 
-		final OnDemandRequest p = new MomentumRequest.Builder().exchanges(new String[] { "NYSE", "NASDAQ" }).build();
+		final MomentumRequest p = new MomentumRequest.Builder().exchanges(new String[] { "NYSE", "NASDAQ" }).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -427,7 +427,7 @@ public class MainTest {
 
 	private void testInstrumentDefinitons() throws IOException {
 
-		final OnDemandRequest p = new InstrumentDefinitionRequest.Builder().exchanges(new String[] { "CME" })
+		final InstrumentDefinitionRequest p = new InstrumentDefinitionRequest.Builder().exchanges(new String[] { "CME" })
 				.maxRecords(100).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
@@ -442,7 +442,7 @@ public class MainTest {
 
 	private void testFuturesSepecifications() throws IOException {
 
-		final OnDemandRequest p = new FuturesSpecificationsRequest.Builder().exchanges(new String[] { "LME" }).build();
+		final FuturesSpecificationsRequest p = new FuturesSpecificationsRequest.Builder().exchanges(new String[] { "LME" }).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -460,7 +460,7 @@ public class MainTest {
 
 	private void testWeather() throws IOException {
 
-		final OnDemandRequest p = new WeatherRequest.Builder().zipCode("60614").build();
+		final WeatherRequest p = new WeatherRequest.Builder().zipCode("60614").build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -473,7 +473,7 @@ public class MainTest {
 
 	private void testLeaders() throws IOException {
 
-		final OnDemandRequest p = new LeadersRequest.Builder().exchanges(new String[] { "NYSE" })
+		final LeadersRequest p = new LeadersRequest.Builder().exchanges(new String[] { "NYSE" })
 				.type(LeadersRequestType.ACTIVE_YTD).assetType(LeadersAssetType.STOCK).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
@@ -487,7 +487,7 @@ public class MainTest {
 
 	private void testCharts() throws IOException {
 
-		final OnDemandRequest p = new ChartRequest.Builder().symbols(new String[] { "GOOG", "NEM" }).build();
+		final ChartRequest p = new ChartRequest.Builder().symbols(new String[] { "GOOG", "NEM" }).build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 
@@ -500,7 +500,7 @@ public class MainTest {
 
 	private void testUSDAGrains() throws IOException {
 
-		final OnDemandRequest p = new USDAGrainsRequest.Builder().build();
+		final USDAGrainsRequest p = new USDAGrainsRequest.Builder().build();
 
 		final String url = OnDemandRequest.BASE_URL + p.endpoint() + "?" + QueryUtil.urlEncodeUTF8(p.parameters());
 


### PR DESCRIPTION
This includes the removal of the `responseMap` which had to be maintained
by hand.
Now the compiler lets you know when you forgot a request's responseType,
or you can specify a custom error message (in the case of the
unimplemented `FuturesExiprationsRequest`).
