### PR TITLE
Barchart Builder should use 'key' instead of 'apikey'

### DIFF
--- a/src/main/java/com/barchart/ondemand/BarchartOnDemandClient.java
+++ b/src/main/java/com/barchart/ondemand/BarchartOnDemandClient.java
@@ -61,7 +61,7 @@ public class BarchartOnDemandClient {
 		sb.append(request.endpoint());
 		sb.append("?");
 		sb.append(QueryUtil.urlEncodeUTF8(request.parameters()));
-		sb.append("&apikey=");
+		sb.append("&key=");
 		sb.append(apiKey);
 
 		final String response = fetchString(sb.toString(), http);


### PR DESCRIPTION
Using 'apikey' returns a message that API key is missing or invalid